### PR TITLE
fix: Better BibTeX 应该保持原型, 不应该翻译为 更好的 BibTeX

### DIFF
--- a/10-Obsidian/Obsidian使用技巧/Zotero和Obsidian联动.md
+++ b/10-Obsidian/Obsidian使用技巧/Zotero和Obsidian联动.md
@@ -7,7 +7,7 @@ author: guyuedeng
 type: other
 draft: false
 editable: false
-modified: 20230801000741
+modified: 20230801103805
 ---
 
 # 鱼与熊掌兼得：Zotero 和 Obsidian 联动
@@ -29,7 +29,7 @@ Obisidan 和 Zotero 都是深受广大用户喜爱的知识管理和文献管理
 > - 插件名称：Zotero Integration
 > - 插件版本：3.0.7
 > - 插件作者：mgmeyers
-> - 插件描述：从 Zotero 插入和导入引文、参考书目、注释和 PDF 注释到 Obsidian。需要更好的 BibTeX 为 Zotero 插件。
+> - 插件描述：从 Zotero 插入和导入引文、参考书目、注释和 PDF 注释到 Obsidian。需要 Better BibTeX 为 Zotero 插件。
 > - 插件项目地址：[点我跳转](https://github.com/mgmeyers/obsidian-zotero-integration)
 
 ### Zotero

--- a/10-Obsidian/Obsidian社区插件/obsidian-zotero-desktop-connector.md
+++ b/10-Obsidian/Obsidian社区插件/obsidian-zotero-desktop-connector.md
@@ -7,20 +7,20 @@ author:
 type: basic
 draft: false
 editable: false
-modified: 20230731231801
+modified: 20230801103849
 ---
 
 # Obsidian 插件：Zotero Integration
 
 ## 概述
 
-从 Zotero 插入和导入引文、参考书目、注释和 PDF 注释到 Obsidian。需要更好的 BibTeX 为 Zotero 插件。
+从 Zotero 插入和导入引文、参考书目、注释和 PDF 注释到 Obsidian。需要 Better BibTeX 为 Zotero 插件。
 
 > [!Note] 插件名片
 > - 插件名称：Zotero Integration
 > - 插件版本：3.0.7
 > - 插件作者：mgmeyers
-> - 插件描述：从 Zotero 插入和导入引文、参考书目、注释和 PDF 注释到 Obsidian。需要更好的 BibTeX 为 Zotero 插件。
+> - 插件描述：从 Zotero 插入和导入引文、参考书目、注释和 PDF 注释到 Obsidian。需要 Better BibTeX 为 Zotero 插件。
 > - 插件项目地址：[点我跳转](https://github.com/mgmeyers/obsidian-zotero-integration)
 
 实战联动指南参考 [[Zotero和Obsidian联动]]


### PR DESCRIPTION
如题,

Zotero 插件 Better BibTeX 译为 "更好的 BibTeX" 是没有必要的. 因为, 

1. 官方并没有提供中文译名
2. 用 "更好的 BibTeX" 为关键词在 谷歌等搜索引擎中几乎无法搜到关于 Better BibTeX 的结果. 因此, 这个翻译徒增文章理解难度.

综上, 建议保持英文原文.