### PR TITLE
Some docs

### DIFF
--- a/03-知识管理工具/自动化软件/quicker/Quicker动作之发送Zotero图片标注至Eagle素材库.md
+++ b/03-知识管理工具/自动化软件/quicker/Quicker动作之发送Zotero图片标注至Eagle素材库.md
@@ -7,7 +7,7 @@ author: 熊猫别熬夜,ImmortalSty
 type: other
 draft: false
 editable: false
-modified: 20240313015049
+modified: 20240317212958
 ---
 
 # Quicker 动作之发送 Zotero 图片标注至 Eagle 素材库
@@ -25,6 +25,10 @@ modified: 20240313015049
 为了更加便捷地导入和管理 Zotero 的文献图片，我尝试使用 Quicker 来实现 Zotero 和 Eagle 的联动。因为我对 Quicker 并不很熟悉，这个动作主要是通过 JS 实现的。在遇到一些问题无法解决时，我向群友 @槑头脑 寻求帮助，最终才顺利完成了该动作的制作，再次非常感谢 @槑头脑 😘。
 
 以下是 Quicker 动作的分享、设计思路、参考资料，以及 Quicker 相关的帮助文档记录。
+
+> [!tip] 如果想将已有的标注图片一次性导入可以参考如下：
+> - [[通过Python脚本实现Eagle管理Zotero标注的图片]]
+> - [[工作流-以图搜图]]
 
 ## Quikcer 动作分享
 

--- a/03-知识管理工具/自动化软件/quicker/Quicker动作之发送Zotero图片标注至Eagle素材库.md
+++ b/03-知识管理工具/自动化软件/quicker/Quicker动作之发送Zotero图片标注至Eagle素材库.md
@@ -1,0 +1,153 @@
+---
+uid: 20240313014614
+title: Quicker 动作之发送 Zotero 图片标注至 Eagle 素材库
+tags: [zotero, Eagle, 文献, 学术研究]
+description: 利用Quicker在阅读文献时将里面的经典图片和重要信息整理起来，建立一个图片素材库
+author: 熊猫别熬夜,ImmortalSty
+type: other
+draft: false
+editable: false
+modified: 20240313015049
+---
+
+# Quicker 动作之发送 Zotero 图片标注至 Eagle 素材库
+
+## 效果
+
+![2024-03-06_Quicker-发送Zotero图片标注至Eagle素材库_IMG-1](https://cdn.pkmer.cn/images/202403130151304.gif!pkmer)
+
+## 背景
+
+为了在阅读文献时将里面的经典图片和重要信息整理起来，建立一个图片素材库而制作的该动作。有时候需要参考相关文献的介绍和描述，就发现单纯的 md 笔记管理难以做到快速预览或者说是全局查阅去快速定位。于是就想以图片为基准的卡片式查阅，图片不局限于科研绘图，还可以是经典的流程图，关键词的文本描述之类的，这样可以让我很快速定位到具体文献的章节，我个人是使用 Eagle 来管理平时的图片素材的，就想以 Eagle 为基础建立一个 Zotero 文献素材库。
+
+> Eagle 是一款图片素材管理软件，可帮助用户有效组织、管理和使用图片素材。它提供直观易用的界面，让用户能快速浏览和搜索图片素材库。此外，Eagle 还提供强大的标签和分类功能，让用户按需整理和归类图片素材，创建自己的图片素材库。[^1]
+
+为了更加便捷地导入和管理 Zotero 的文献图片，我尝试使用 Quicker 来实现 Zotero 和 Eagle 的联动。因为我对 Quicker 并不很熟悉，这个动作主要是通过 JS 实现的。在遇到一些问题无法解决时，我向群友 @槑头脑 寻求帮助，最终才顺利完成了该动作的制作，再次非常感谢 @槑头脑 😘。
+
+以下是 Quicker 动作的分享、设计思路、参考资料，以及 Quicker 相关的帮助文档记录。
+
+## Quikcer 动作分享
+
+> [!note]+ Quicker 动作：[ZoteroToEagle](https://getquicker.net/Sharedaction?code=85b92307-2003-47bd-afea-08dc426a44c3)
+> ![2024-03-06_Quicker-发送Zotero图片标注至Eagle素材库_IMG-2](https://cdn.pkmer.cn/images/202403130151305.png!pkmer)
+
+### 使用方法
+
+只需要最开始的时候配置 Zotero 的数据存储位置 `ZoteroPath` ，可能会要 node.js 的环境：
+
+![2024-03-06_Quicker-发送Zotero图片标注至Eagle素材库_IMG-3](https://cdn.pkmer.cn/images/202403130151306.png!pkmer)
+
+## 制作思路
+
+由 Quicker 来执行 `Ctrl + C` 复制标注信息 `{ZoteroText}`，`Ctrl + Shift + C` 复制条目 `{ZoteroItem}`，以及 Zotero 的数据存储位置 `{ZoteroPath}`，通过 node.js 来发送参数到 `Zotero2Eagle.js` 中：
+
+```js
+node Zotero2Eagle.js "{ZoteroPath}" "{ZoteroText}" "{ZoteroItem}"
+```
+
+该 `Zotero2Eagle.js` 脚本文件已整合到 Quicker 中，第一次会加载 Quicker 动作会在 `{ZoteroPath}` 文件夹下 (eg: `D:/Zotero`) 生成该脚本文件：
+
+![2024-03-06_Quicker-发送Zotero图片标注至Eagle素材库_IMG-4](https://cdn.pkmer.cn/images/202403130151307.png!pkmer)
+
+### Zotero2Eagle.js 源码
+
+```js
+const process = require('process');
+const zoteroPath = process.argv[2] ? process.argv[2] : "";
+
+if (!zoteroPath) {
+    console.log("No zoteroPath found");
+    process.exit(0);
+}
+
+const ZoteroText = process.argv[3] ? process.argv[3] : "";
+const ZoteroItem = process.argv[4] ? process.argv[4] : "";
+
+const { log } = console;
+log({ ZoteroText, ZoteroItem });
+
+const { zotero_link, zotero_comment, zotero_image, zotero_year } = match_zotero_data(ZoteroText);
+log({ zotero_link, zotero_comment, zotero_image, zotero_year });
+if (!zotero_image) {
+    console.log("No image found");
+    process.exit(0);
+}
+
+// Zotero Library 路径
+const zotero_image_path = `${zoteroPath}/cache/library/${zotero_image}`;
+
+const { zotero_title, zotero_author } = match_zotero_item(ZoteroItem);
+
+const data = {
+    "path": zotero_image_path,
+    "website": zotero_link,
+    "tags": [zotero_author, zotero_year, zotero_title].filter(Boolean),
+    "annotation": zotero_comment,
+    "folderId": "KEHB8I2C9F23H",
+};
+
+const requestOptions = {
+    method: 'POST',
+    body: JSON.stringify(data),
+    redirect: 'follow'
+};
+
+fetch("http://localhost:41595/api/item/addFromPath", requestOptions)
+    .then(response => response.json())
+    .then(result => console.log(result))
+    .catch(error => console.log('error', error));
+
+function match_zotero_data(text) {
+    const regex_link = /\[pdf\]\((.*)\)\)/;
+    const regex_comment = /.*\)\).*\)\)([\s\S]*)/;
+    const regex_image = /annotation=(\w*)/;
+    const regex_year = /,\s(\d{4})/;
+
+    const zotero_link = text.match(regex_link) ? text.match(regex_link)[1] : "";
+    const zotero_comment = text.match(regex_comment) ? text.match(regex_comment)[1] : "";
+    const zotero_image = text.match(regex_image) ? text.match(regex_image)[1] + ".png" : "";
+    const zotero_year = text.match(regex_year) ? text.match(regex_year)[1] : "";
+
+
+    return { zotero_link, zotero_comment, zotero_image, zotero_year };
+}
+
+function match_zotero_item(text) {
+    const regex_title = /(《.*》)/;
+    const regex_author = /\]\s(.*?),/;
+
+    const zotero_title = text.match(regex_title) ? text.match(regex_title)[1] : "";
+    const zotero_author = text.match(regex_author) ? text.match(regex_author)[1] : "";
+
+    return { zotero_title, zotero_author };
+}
+
+```
+
+### 修改参数
+
+```js
+const data = {
+    "path": zotero_image_path, // 本地图片路径
+    "website": zotero_link, // Zotero外部回链
+    "tags": [zotero_author, zotero_year, zotero_title].filter(Boolean),  // 条目的作者，年份，标题信息，如果提取成功(布尔值)则添加
+    "annotation": zotero_comment, // Zotero的图片注释信息
+    "folderId": "KEHB8I2C9F23H", // 随便填的，如果想指定Eagle的文件夹,请将文件夹的ID替换一下就行
+};
+```
+
+> 还有一些参数，比如 `name` 图片名的设置，不设置则保持默认的图片名称，还有 `token` 的设置，详细可参考：[EagleAPI-添加本地文件](https://www.yuque.com/augus-gsjgn/eagle-api/suaf2q)
+
+## 参考资料
+
+- [如何将命令行参数传递给 Node.js 应用程序？](https://ivwv.netlify.app/posts/technology/node/how-to-pass-cmd-line-args-to-node.html#%E5%B0%86%E5%8F%82%E6%95%B0%E4%BC%A0%E9%80%92%E7%BB%99-node-js-%E5%BA%94%E7%94%A8%E7%A8%8B%E5%BA%8F)
+- [EagleAPI-添加本地文件(api、item、addFromPath)](https://www.yuque.com/augus-gsjgn/eagle-api/suaf2q)
+- [[工作流-以图搜图]]
+
+### Quicker 的一些帮助文档
+
+- [Quicker用户手册 - Quicker](https://getquicker.net/KC/Help)
+- [Tiny文本编辑器 - by 龙少 - 动作信息 - Quicker](https://getquicker.net/Sharedaction?code=679da246-89af-4a67-f467-08d8f95763cd)
+	- 用于编辑 Quicker 动作的介绍文本编辑器，非常推荐
+
+[^1]: [[通过Python脚本实现Eagle管理Zotero标注的图片]]

--- a/03-知识管理工具/自动化软件/quicker/开始Quicker吧.md
+++ b/03-知识管理工具/自动化软件/quicker/开始Quicker吧.md
@@ -97,7 +97,8 @@ modified: 20240105203946
 - [[表格操作占用快捷键过多的解决方案]]：ImmortalSty；
 - [[Quicker动作之以PotPlayer为基础的视频时间戳]]：ImmortalSty；
 - [[Quicker动作之自定义Zotero标注到Obsidian]]：熊猫别熬夜；
-- [[Quicker动作之BookxNote和Obsidian联动]]：熊猫别熬夜。
+- [[Quicker动作之BookxNote和Obsidian联动]]：熊猫别熬夜;
+- [[Quicker动作之发送Zotero图片标注至Eagle素材库]]：熊猫别熬夜;
 - [[Quicker动作之截图贴图]]
 - [[使用 Quicker 与 Thino 进行联动
 - [[Quicker搜索之用搜索框快速搜索PKMer]]

--- a/10-Obsidian/Obsidian社区插件/Excalidraw/obsidian-excalidraw-plugin.md
+++ b/10-Obsidian/Obsidian社区插件/Excalidraw/obsidian-excalidraw-plugin.md
@@ -7,7 +7,7 @@ author: windilycloud
 type: basic
 draft: false
 editable: false
-modified: 20240131141540
+modified: 20240317230024
 ---
 
 # Obsidian 插件：Excalidraw 完美的绘图工具
@@ -141,6 +141,8 @@ Excalidraw 在早期是有很多问题的，比如没有手写压感，插图太
 
 > EA 脚本开发的介绍： [[ExcalidrawAutomate index]]
 
+- 实用脚本
+	- [[自定义Excalidraw脚本-QuickSwitchFrame-简单的Frame切换大纲]] by 熊猫别熬夜
 - 外部联用
 	- [[自定义Excalidraw脚本-实现Zotero与Excalidraw的拖拽联动]] by 熊猫别熬夜
 	- [[自定义Excalidraw脚本-实现Excalidraw与BookxNote的联动]] by 熊猫别熬夜
@@ -156,11 +158,11 @@ Excalidraw 在早期是有很多问题的，比如没有手写压感，插图太
 	- [[自定义Excalidraw脚本-默认应用打开图片]] by 熊猫别熬夜
 	- [[自定义Excalidraw脚本-OCR自动提取图片文字]] by 熊猫别熬夜
 	- [[自定义Excalidraw脚本-AdjustImageSize-统一多个图片宽度或者高度]] by 一鸣惊人,熊猫别熬夜
+	- [[自定义Excalidraw脚本-上传画板中的图片到图床]] by 熊猫别熬夜
 - 画布演示
 	- [[Excalidraw脚本-Slideshow完美实现画板幻灯片演示的脚本]]
 	- [[自定义Excalidraw脚本-画板局部或者全局播放动画]] by 熊猫别熬夜
 	- [[自定义Excalidraw脚本-画板与 Kanban 得梦幻结合-像PPT一样演示]] by 熊猫别熬夜
-	- [[自定义Excalidraw脚本-QuickSwitchFrame-简单的Frame切换大纲]] by 熊猫别熬夜
 
 ### CSS 美化
 

--- a/10-Obsidian/Obsidian社区插件/Excalidraw/obsidian-excalidraw-plugin.md
+++ b/10-Obsidian/Obsidian社区插件/Excalidraw/obsidian-excalidraw-plugin.md
@@ -160,6 +160,7 @@ Excalidraw 在早期是有很多问题的，比如没有手写压感，插图太
 	- [[Excalidraw脚本-Slideshow完美实现画板幻灯片演示的脚本]]
 	- [[自定义Excalidraw脚本-画板局部或者全局播放动画]] by 熊猫别熬夜
 	- [[自定义Excalidraw脚本-画板与 Kanban 得梦幻结合-像PPT一样演示]] by 熊猫别熬夜
+	- [[自定义Excalidraw脚本-QuickSwitchFrame-简单的Frame切换大纲]] by 熊猫别熬夜
 
 ### CSS 美化
 

--- a/10-Obsidian/Obsidian社区插件/Excalidraw/自定义Excalidraw脚本-OCR自动提取图片文字.md
+++ b/10-Obsidian/Obsidian社区插件/Excalidraw/自定义Excalidraw脚本-OCR自动提取图片文字.md
@@ -7,7 +7,7 @@ author: 熊猫别熬夜
 type: other
 draft: false
 editable: false
-modified: 20240122221659
+modified: 20240312174517
 ---
 
 # 自定义 Excalidraw 脚本 - OCR 自动提取图片文字
@@ -16,6 +16,26 @@ modified: 20240122221659
 > ![自定义 Excalidraw 脚本 -OCR 自动提取图片文字](https://cdn.pkmer.cn/images/202312291613601.png!pkmer)
 
 > 对 Excalidraw 的图片进行 OCR，并保留文本信息在图片中，可以编辑修改、重新 OCR 和进行批量识别。
+
+## 脚本文件
+
+### 脚本链接
+
+- 链接：[TextExtractor.md](https://github.com/PandaNocturne/ExcalidrawScripts/blob/master/PandaScripts/TextExtractor.md)
+
+可以用 Excalidraw Scripts 代码块安装：
+
+```excalidraw-script-install
+https://raw.githubusercontent.com/PandaNocturne/ExcalidrawScripts/master/PandaScripts/TextExtractor.md
+```
+
+### 配置文件
+
+> 配置文件 [paddleocr.zip](https://drive.weixin.qq.com/s?k=AGAAFQdIAEsv0SkXa4)，解压到到 `.obsidian` 文件夹下即可采用脚本的默认配置：
+
+![image.png](https://cdn.pkmer.cn/images/202403121744578.png!pkmer)
+
+![自定义Excalidraw脚本-OCR自动提取图片文字](https://cdn.pkmer.cn/images/202403121744578.png!pkmer)
 
 ## 脚本思路
 

--- a/10-Obsidian/Obsidian社区插件/Excalidraw/自定义Excalidraw脚本-OCR自动提取图片文字.md
+++ b/10-Obsidian/Obsidian社区插件/Excalidraw/自定义Excalidraw脚本-OCR自动提取图片文字.md
@@ -33,8 +33,6 @@ https://raw.githubusercontent.com/PandaNocturne/ExcalidrawScripts/master/PandaSc
 
 > 配置文件 [paddleocr.zip](https://drive.weixin.qq.com/s?k=AGAAFQdIAEsv0SkXa4)，解压到到 `.obsidian` 文件夹下即可采用脚本的默认配置：
 
-![image.png](https://cdn.pkmer.cn/images/202403121744578.png!pkmer)
-
 ![自定义Excalidraw脚本-OCR自动提取图片文字](https://cdn.pkmer.cn/images/202403121744578.png!pkmer)
 
 ## 脚本思路

--- a/10-Obsidian/Obsidian社区插件/Excalidraw/自定义Excalidraw脚本-QuickSwitchFrame-简单的Frame切换大纲.md
+++ b/10-Obsidian/Obsidian社区插件/Excalidraw/自定义Excalidraw脚本-QuickSwitchFrame-简单的Frame切换大纲.md
@@ -1,0 +1,68 @@
+---
+uid: 20240311180729
+title: 自定义 Excalidraw 脚本 -QuickSwitchFrame- 简单的 Frame 切换大纲
+tags: [Excalidraw脚本]
+description: 简单的 Frame 切换大纲
+author: 熊猫别熬夜
+type: other
+draft: false
+editable: false
+modified: 20240311181006
+---
+
+# 自定义 Excalidraw 脚本 -QuickSwitchFrame- 简单的 Frame 切换大纲
+
+## 效果演示
+
+![2024-03-08_自定义Excalidraw脚本-QuickSwitchFrame-简单的Frame切换大纲_IMG-1](https://cdn.pkmer.cn/images/202403111810108.gif!pkmer)
+
+## 背景
+
+在之前的 [[自定义Excalidraw脚本-画板与 Kanban 得梦幻结合-像PPT一样演示]] 中可生成侧边的大纲对 Frame 进行大纲显示、预览、排序等功能，但是如果是编辑过程中只想快速跳转到某个区域，单独分离出一个 Kanban 的侧边栏就比较占地方了，想到了我常用的 another quick Switcher 的标题切换，通过下拉菜单聚焦于画板的 Frame，这样更加方便。
+
+## 脚本安装
+
+脚本安装可以根据源码来安装，也可以通过 Excalidraw 插件提供的脚本安装代码块来安装
+
+- 代码块链接方法：
+	- 优点：一键安装脚本和图标，操作方便，后续脚本更新可以检测
+	- 缺点：国内需要可访问 GitHub 的网络
+- 源码拷贝方式：
+	- 优点：不需要特殊网络
+	- 缺点：需要手动复制源码，这个过程很容易出问题，没有图标，脚本更新无法检测…
+
+> PS：之后我的脚本更新或者 BUG 修复，可能不会更新到网站，而是直接更新到 GitHub，因为这样对我来说比较方便点而且快速点。
+
+### 代码块链接方法
+
+````
+```excalidraw-script-install
+https://raw.githubusercontent.com/PandaNocturne/ExcalidrawScripts/master/PandaScripts/QuickSwitchFrame.md
+```
+````
+
+将上述代码块放到一个 **md 文件**，阅读模式下该代码块会显示为 <kbd>安装脚本</kbd>的按钮，点击安装之后，更新为<kbd>脚本已是最新 - 点击重新安装</kbd>，即当前脚本已经安装，在 Excalidraw 画布界面的侧边**Obsidian 工具面板**中可以查看。
+
+![Pasted image 20240311163906](https://cdn.pkmer.cn/images/202403111810109.png!pkmer)
+
+![Pasted image 20240311164317](https://cdn.pkmer.cn/images/202403111810110.png!pkmer)
+
+### 源码拷贝方式
+
+```js
+const ea2 = ExcalidrawAutomate;
+const frameElements = ea2.getViewElements().filter(el => el.type === "frame");
+const choices = frameElements.map(el => el.name);
+choices.sort();
+
+let choice = "";
+choice = await utils.suggester(choices, choices, "请选择要跳转的大纲");
+// if (!choice) return;
+
+const selectedElement = frameElements.find(el => el.name === choice);
+if (selectedElement) {
+    // 执行跳转到选定元素的操作
+    api = ea2.getExcalidrawAPI();
+    api.zoomToFit([selectedElement], 10);
+}
+```

--- a/10-Obsidian/Obsidian社区插件/Excalidraw/自定义Excalidraw脚本-实现Zotero与Excalidraw的拖拽联动.md
+++ b/10-Obsidian/Obsidian社区插件/Excalidraw/自定义Excalidraw脚本-实现Zotero与Excalidraw的拖拽联动.md
@@ -7,7 +7,7 @@ author: 熊猫别熬夜,ProudBenzene,y6n-u9h
 type: other
 draft: false
 editable: false
-modified: 20240116121504
+modified: 20240312002704
 ---
 
 # 自定义 Excalidraw 脚本：实现 Zotero 与 Excalidraw 的拖拽联动
@@ -59,7 +59,30 @@ modified: 20240116121504
  > 1. 如果配置无误的情况下，请重启 Obsidian，重新插入试试；
  > 2. 如果确定自己配置不存在问题却依旧出现问题，请截图并说明自己存在的问题之后在群里再@。
 
-### Zotero to Excalidraw 脚本
+## 脚本安装
+
+脚本安装可以根据源码来安装，也可以通过 Excalidraw 插件提供的脚本安装代码块来安装
+
+- 代码块链接方法：
+	- 优点：一键安装脚本和图标，操作方便，后续脚本更新可以检测
+	- 缺点：国内需要可访问 GitHub 的网络
+- 源码拷贝方式：
+	- 优点：不需要特殊网络
+	- 缺点：需要手动复制源码，这个过程很容易出问题，没有图标，脚本更新无法检测…
+
+> PS：之后我的脚本更新或者 BUG 修复，可能不会更新到网站，而是直接更新到 GitHub，因为这样对我来说比较方便点而且快速点。
+
+### 代码块链接方法
+
+````
+```excalidraw-script-install
+https://raw.githubusercontent.com/PandaNocturne/ExcalidrawScripts/master/PandaScripts/ZoteroToExcalidraw.md
+```
+````
+
+将上述代码块放到一个 **md 文件**，阅读模式下该代码块会显示为 <kbd>安装脚本</kbd>的按钮，点击安装之后，更新为<kbd>脚本已是最新 - 点击重新安装</kbd>，即当前脚本已经安装，在 Excalidraw 画布界面的侧边**Obsidian 工具面板**中可以查看。
+
+## 源码拷贝方式
 
 ```javascript
 let settings = ea.getScriptSettings();
@@ -153,21 +176,22 @@ el.ondrop = async function (event) {
 
 		zotero_txt = match_zotero_txt(insert_txt);
 		zotero_author = match_zotero_author(insert_txt);
+		zotero_link = match_zotero_link(insert_txt);
 		if (zotero_author) {
-			zotero_author = `\n(${zotero_author})`;
+			zotero_author = `[(${zotero_author})](${zotero_link})`;
 		};
 		zotero_comment = match_zotero_comment(insert_txt);
 		if (zotero_comment) {
-			zotero_comment = `\n\n📝：${zotero_comment}`;
+			zotero_comment = `\n\n${zotero_comment}`;
 		};
-		zotero_link = match_zotero_link(insert_txt);
 
 		if (zotero_txt) {
 			console.log("ZoteroText");
-
-			let id = await ea.addText(0, 0, `📖：${zotero_txt}${zotero_author}${zotero_comment}`, { width: 600, box: true, wrapAt: 90, textAlign: "left", textVerticalAlign: "middle", box: "box" });
+			const totalText = `${zotero_txt}${zotero_comment}`;
+			let width = totalText.length > 30 ? 600 : totalText.length * 20;
+			let id = await ea.addText(0, 0, `${zotero_txt}${zotero_author}${zotero_comment}`, { width: width, box: true, wrapAt:99, textAlign: "left", textVerticalAlign: "middle", box: "box" });
 			let el = ea.getElement(id);
-			el.link = zotero_link;
+			// el.link = zotero_link;
 			await ea.addElementsToView(true, true, false);
 			if (ea.targetView.draginfoDiv) {
 				document.body.removeChild(ea.targetView.draginfoDiv);
@@ -191,7 +215,7 @@ el.ondrop = async function (event) {
 
 			let id = await ea.addImage(0, 0, zotero_image_name);
 			let el = ea.getElement(id);
-			el.link = zotero_link;
+			el.link = zotero_author;
 
 			await ea.addElementsToView(true, true, false);
 			if (ea.targetView.draginfoDiv) {
@@ -207,7 +231,8 @@ el.ondrop = async function (event) {
 		// 格式化文本(去空格、全角转半角)  
 		insert_txt = processText(insert_txt);
 		console.log("文本格式化");
-		await ea.addText(0, 0, `${insert_txt} `, { width: 400, box: true, wrapAt: 90, textAlign: "left", textVerticalAlign: "middle", box: "box" });
+		let width = insert_txt.length > 30 ? 600 : insert_txt.length * 15;
+		await ea.addText(0, 0, `${insert_txt} `, { width: width, box: true, wrapAt: 90, textAlign: "left", textVerticalAlign: "middle", box: "box" });
 		// let el = ea.getElement(id);
 		await ea.addElementsToView(true, true, false);
 		if (ea.targetView.draginfoDiv) {
@@ -273,6 +298,7 @@ function match_zotero_image(text) {
 	const matches = text.match(regex);
 	return matches ? matches[1] : "";
 }
+
 ```
 
 该脚本的中心思想就是通过拖拽的文本，定位到图片名，从而复制该图片到 OB 的笔记库中，并对拖拽的文本进行处理，去除多余的空格以及全角转半角，拆分为 zotero_txt、zotero_author、zotero_link、zotero_comment、zotero_image 这 5 个文本，自定义组合：

--- a/10-Obsidian/Obsidian社区插件/Excalidraw/自定义Excalidraw脚本-快速插入时间戳笔记.md
+++ b/10-Obsidian/Obsidian社区插件/Excalidraw/自定义Excalidraw脚本-快速插入时间戳笔记.md
@@ -22,7 +22,7 @@ modified: 20231117151634
 
 ## 快速添加时间戳笔记
 
-![自定义 Excalidraw 脚本 - 快速插入时间戳笔记](https://cdn.pkmer.cn/images/234.gif!pkmer)
+![2023-11-10_自定义Excalidraw脚本-快速插入时间戳笔记_IMG-3](https://cdn.pkmer.cn/images/202403160219335.gif!pkmer)
 
 > 按时间戳形式命名，利用 quickaddApi.date.now("YYYY-MM-DD") 等命名建立的，请根据需求来设置
 

--- a/10-Obsidian/Obsidian社区插件/Excalidraw/自定义Excalidraw脚本-画板与 Kanban 得梦幻结合-像PPT一样演示.md
+++ b/10-Obsidian/Obsidian社区插件/Excalidraw/自定义Excalidraw脚本-画板与 Kanban 得梦幻结合-像PPT一样演示.md
@@ -7,7 +7,7 @@ author: 熊猫别熬夜
 type: other
 draft: false
 editable: false
-modified: 20240122223401
+modified: 20240311180336
 ---
 
 # 自定义 Excalidraw 脚本 - 画板与 Kanban 得梦幻结合 - 像 PPT 一样演示
@@ -84,6 +84,30 @@ Kanban 文件的刷新稍微有点延迟，而且 Excalidraw 的局部引用视�
 
 [[Excalidraw如何安装脚本_脚本设置介绍]]
 
+脚本安装可以根据源码来安装，也可以通过 Excalidraw 插件提供的脚本安装代码块来安装
+
+- 代码块链接方法：
+	- 优点：一键安装脚本和图标，操作方便，后续脚本更新可以检测
+	- 缺点：国内需要可访问 GitHub 的网络
+- 源码拷贝方式：
+	- 优点：不需要特殊网络
+	- 缺点：需要手动复制源码，这个过程很容易出问题，没有图标，脚本更新无法检测…
+
+> PS：之后我的脚本更新或者 BUG 修复，可能不会更新到网站，而是直接更新到 GitHub，因为这样对我来说比较方便点而且快速点。
+
+### 代码块链接方法
+
+````
+```excalidraw-script-install
+https://raw.githubusercontent.com/PandaNocturne/ExcalidrawScripts/master/PandaScripts/FrameKanban.md
+```
+````
+
+将上述代码块放到一个 **md 文件**，阅读模式下该代码块会显示为 <kbd>安装脚本</kbd>的按钮，点击安装之后，更新为<kbd>脚本已是最新 - 点击重新安装</kbd>，即当前脚本已经安装，在 Excalidraw 画布界面的侧边**Obsidian 工具面板**中可以查看。
+
+
+### 源码拷贝方式
+
 ```js
 const fs = require('fs');
 const activefile = app.workspace.getActiveFile();
@@ -111,21 +135,39 @@ const kanbanFilePath = settings["动态Kanban.md的路径"].value;
 const KanbanPath = app.vault.getAbstractFileByPath(kanbanFilePath);
 const kanbanFullPath = app.vault.adapter.getFullPath(kanbanFilePath);
 
-const KanbanLaneWidth = settings["Kanban的宽度"].value;
-
 await ea.addElementsToView();
+
 const frameElements = ea.getViewElements().filter(el => el.type === "frame");
 const fileName = app.workspace.getActiveFile().name;
-const choices = ["生成Frame卡片(有缩略图)", "生成Frame大纲(无缩略图)", "对Frame进行排序", "打开Kanban文件"];
+const choices = ["生成Frame卡片(有缩略图)", "生成Frame大纲(无缩略图)", "对Frame进行排序", "打开Kanban文件", "重设Kanban宽度"];
 
-const choice = await utils.suggester(choices, choices, "是否生成缩略图或者排序");
+// ! 如果选择了一个或多个frame元素，则不弹出选项框，直接诶生成生成Frame大纲
+const selectedTextElements = ea.getViewSelectedElements().filter(el => el.type === "frame");
+let choice = "";
+if (selectedTextElements.length >= 1) {
+    choice = choices[1];
+} else {
+    choice = await utils.suggester(choices, choices, "是否生成缩略图或者排序");
+}
+
+// let choice = "";
+// choice = await utils.suggester(choices, choices, "是否生成缩略图或者排序");
+
 if (typeof choice === "undefined") {
     return; // 退出函数或程序
 }
 
+// ! 设置看板宽度
+let kanbanWidth = settings["Kanban的宽度"].value;
+if (choice === choices[4]) {
+    kanbanWidth = await utils.inputPrompt("请设置看板宽度", "请设置看板宽度。注意为数值型", kanbanWidth,1);
+    settings["Kanban的宽度"].value = kanbanWidth;
+    ea.setScriptSettings(settings);
+    choice = choices[1];
+}
+
 // ! open打开形式
 if (choice === choices[3]) {
-
     const choices = ["新标签页", "垂直标签页", "水平标签页", "悬浮标签页，需要安装Hover插件"];
     const choice = await utils.suggester(choices, choices, "是否生成缩略图或者排序");
     if (choice === choices[0]) {
@@ -164,7 +206,7 @@ if (choice === choices[2]) {
         }
     });
     await ea.addElementsToView();
-    
+
     return;
 }
 
@@ -200,7 +242,7 @@ const kanbanYaml = "---\n\nkanban-plugin: basic\n\n---\n\n";
 
 const kanbanSetting = {
     "kanban-plugin": "basic",
-    "lane-width": KanbanLaneWidth,
+    "lane-width": kanbanWidth,
     "show-checkboxes": false,
     "archive-with-date": false
 };
@@ -249,11 +291,12 @@ async function processFile(allFrameEls, frameKanbanFullPath, fileName) {
                         console.log(selectedEl.name);
                         elText = `Frame${j < 10 ? 0 : ""}${j}_${elText.replace(/Frame\d+_/, "")}`;
                         selectedEl.name = elText;
-                        ea.addElementsToView();
                         lines[i] = lines[i].replace(/(^-\s.*?\[\[.*?\.md#\^\w+=[a-zA-Z0-9-_]+\|?)(.*?)(\]\].*)/, `$1${elText}$3`);
                     }
                 }
             }
+            ea.copyViewElementsToEAforEditing(allFrameEls);
+            ea.addElementsToView();
             updatedElements.push(lines[i]);
         }
         // console.log(updatedElements);
@@ -263,7 +306,6 @@ async function processFile(allFrameEls, frameKanbanFullPath, fileName) {
         console.error(error);
     }
 }
-
 
 ```
 
@@ -279,4 +321,12 @@ async function processFile(allFrameEls, frameKanbanFullPath, fileName) {
 - 修改选项为中文：
 	- ![自定义Excalidraw脚本-画板与 Kanban 得梦幻结合-像PPT一样演示](https://cdn.pkmer.cn/images/202403021103678.png!pkmer)
 - 排序后会将 Frame 名称添加到文档的 aliases 区 (添加文档别名方便搜索)
-	-  ![自定义Excalidraw脚本-画板与 Kanban 得梦幻结合-像PPT一样演示](https://cdn.pkmer.cn/images/202403021332452.png!pkmer)
+	- ![自定义Excalidraw脚本-画板与 Kanban 得梦幻结合-像PPT一样演示](https://cdn.pkmer.cn/images/202403021332452.png!pkmer)
+
+### 2024-03-06：添加设置 Kanban 宽度选项
+
+- [x] 当选中一个 Frame 时，不再弹出选项框，而是更新 frame 大纲 (无缩略图) ✅ 2024-03-05
+- [x] 修复对 Frame 排序后无法生效的问题 ✅ 2024-03-05
+- [x] 添加设置 Kanban 宽度选项 ->可以随时调整宽度 ✅ 2024-03-06
+	- 以后需要配置参数的脚本全部设置可自动弹窗输入设置
+	- ![自定义Excalidraw脚本-画板与 Kanban 得梦幻结合-像PPT一样演示](https://cdn.pkmer.cn/images/202403111823035.png!pkmer)

--- a/10-Obsidian/Obsidian社区插件/Excalidraw/自定义Excalidraw脚本-默认应用打开图片.md
+++ b/10-Obsidian/Obsidian社区插件/Excalidraw/自定义Excalidraw脚本-默认应用打开图片.md
@@ -7,7 +7,7 @@ author: 熊猫别熬夜
 type: other
 draft: false
 editable: false
-modified: 20231206204934
+modified: 20240311234354
 ---
 
 # 自定义 Excalidraw 脚本 - 默认应用打开图片
@@ -20,17 +20,74 @@ modified: 20231206204934
 > 默认软件打开画板中选中的图片，适用于当您想用默认软件编辑笔记画板中的图片时，采用的一个快捷方式。
 > ![Pasted image 20231014171319](https://cdn.pkmer.cn/images/Pasted%20image%2020231014171319.png!pkmer)
 
-## 代码示意
+## 设置不同软件打开
+
+在 Excalidraw 插件设置里面可以设置参数，除了默认应用打开外，还可以自定义多个不同软件打开：
+
+![2023-11-24_自定义Excalidraw脚本-默认应用打开图片_IMG-2](https://cdn.pkmer.cn/images/202403112344315.png!pkmer)
+
+![2023-11-24_自定义Excalidraw脚本-默认应用打开图片_IMG-3](https://cdn.pkmer.cn/images/202403112344316.png!pkmer)
+
+## 脚本安装
+
+脚本安装可以根据源码来安装，也可以通过 Excalidraw 插件提供的脚本安装代码块来安装
+
+- 代码块链接方法：
+	- 优点：一键安装脚本和图标，操作方便，后续脚本更新可以检测
+	- 缺点：国内需要可访问 GitHub 的网络
+- 源码拷贝方式：
+	- 优点：不需要特殊网络
+	- 缺点：需要手动复制源码，这个过程很容易出问题，没有图标，脚本更新无法检测…
+
+> PS：之后我的脚本更新或者 BUG 修复，可能不会更新到网站，而是直接更新到 GitHub，因为这样对我来说比较方便点而且快速点。
+
+### 代码块链接方法
+
+````
+```excalidraw-script-install
+https://raw.githubusercontent.com/PandaNocturne/ExcalidrawScripts/master/PandaScripts/OpenSelectImage.md
+```
+````
+
+将上述代码块放到一个 **md 文件**，阅读模式下该代码块会显示为 <kbd>安装脚本</kbd>的按钮，点击安装之后，更新为<kbd>脚本已是最新 - 点击重新安装</kbd>，即当前脚本已经安装，在 Excalidraw 画布界面的侧边**Obsidian 工具面板**中可以查看。
+
+## 源码拷贝方式
 
 ```javascript
-await ea.addElementsToView(); //to ensure all images are saved into the file
+/*
+ * @Author: 熊猫别熬夜 
+ * @Date: 2024-03-11 23:41:55 
+ * @Last Modified by:   熊猫别熬夜 
+ * @Last Modified time: 2024-03-11 23:41:55 
+ */
+
+await ea.addElementsToView();
 const { exec } = require('child_process');
+
+// 设置 quickerInsetNote 模板设置
+let settings = ea.getScriptSettings();
+//set default values on first run
+if (!settings["OpenSelectImage"]) {
+  settings = {
+    "OpenSelectImage": {
+      value: "D:\\FastStone Image Viewer\\FSViewer.exe",
+      height: "250px",
+      description: "其他默认图片编辑软件路径，以换行分隔"
+    },
+  };
+  ea.setScriptSettings(settings);
+}
 
 const img = ea.getViewSelectedElements().filter(el => el.type === "image");
 if (img.length === 0) {
   new Notice("No image is selected");
   return;
 }
+
+let choices = settings["OpenSelectImage"].value.split("\n");
+choices.unshift("默认", "打开文件夹");
+const choice = await utils.suggester(choices.map(i => i.split("\\").at(-1).replace("\.exe", "")), choices, "图片打开的方式");
+if (!choice) return;
 
 for (i of img) {
   const currentPath = ea.plugin.filesMaster.get(i.fileId).path;
@@ -39,33 +96,34 @@ for (i of img) {
     new Notice("Can't find file: " + currentPath);
     continue;
   }
-  const pathNoExtension = file.path.substring(0, file.path.length - file.extension.length - 1);
-  let fileName = file.path;
-  let fileBasePath = file.vault.adapter.basePath;
-  let filePath = `${fileBasePath}/${fileName}`;
 
-  // 根据操作系统使用默认应用打开文件
-  let openCommand;
-  if (navigator.platform.includes("Win")) {
-    openCommand = `start "" "${filePath}"`;
-  } else if (navigator.platform.includes("Mac")) {
-    openCommand = `open "" "${filePath}"`;
+  const filePath = file.path;
+  if (choice === choices[0]) {
+    // 用默认应用打开
+    app.openWithDefaultApp(filePath);
+  } else if (choice === choices[1]) {
+    // 使用打开当前笔记文件夹
+    app.showInFolder(filePath);
   } else {
-    new Notice("不支持该平台");
-    return;
+    // 获取库的基本路径
+    const fileBasePath = file.vault.adapter.basePath;
+    // 获取文件的完整路径
+    const fileFullPath = `${fileBasePath}/${filePath}`;
+    exec(`"${choice}" "${fileFullPath}"`, (error, stdout, stderr) => {
+      if (error) {
+        new Notice(`Error opening file: ${error.message}`);
+        return;
+      }
+      if (stderr) {
+        new Notice(`Error opening file: ${stderr}`);
+        return;
+      }
+      new Notice(`File opened with ${choice}`);
+    });
   }
-
-  // 使用默认应用打开文件
-  exec(openCommand, (error, stdout, stderr) => {
-    if (error) {
-      console.error(`打开文件时出错: ${error.message}`);
-      return;
-    }
-    if (stderr) {
-      console.error(`打开文件时出错: ${stderr}`);
-      return;
-    }
-    console.log(`文件已成功打开`);
-  });
 }
 ```
+
+## ChangeLog
+
+- 2024-03-11：设置选项框，除了默认应用打开外，还可以自定义多个不同软件打开

--- a/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹).md
+++ b/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹).md
@@ -1,16 +1,13 @@
 ---
 uid: 20240316021039
 title: QuickAdd 脚本 -Obsidian 批量重命名 (笔记 - 附件 - 文件夹)
-tags:
-  - quickadd脚本
-  - 批量处理
-  - 重命名
+tags: [quickadd脚本, 批量处理, 重命名]
 description: 批量给笔记、附件、以及文件夹进行重命名
 author: 熊猫别熬夜
 type: other
 draft: false
 editable: false
-modified: 20240316021234
+modified: 20240316224558
 ---
 
 # QuickAdd 脚本 -Obsidian 批量重命名 (笔记 - 附件 - 文件夹)

--- a/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹).md
+++ b/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹).md
@@ -1,0 +1,224 @@
+---
+uid: 20240316021039
+title: QuickAdd 脚本 -Obsidian 批量重命名 (笔记 - 附件 - 文件夹)
+tags:
+  - quickadd脚本
+  - 批量处理
+  - 重命名
+description: 批量给笔记、附件、以及文件夹进行重命名
+author: 熊猫别熬夜
+type: other
+draft: false
+editable: false
+modified: 20240316021234
+---
+
+# QuickAdd 脚本 -Obsidian 批量重命名 (笔记 - 附件 - 文件夹)
+
+## 背景
+
+这个脚本是用来批量给笔记、附件、以及文件夹进行重命名，主要是针对存在特殊格式文本进行统一化，如果时间 YYYYMMDD 改为 YYYY-MM-DD 之类的，或者批量替换关键词：Quickadd->QuickAdd，给 Excalidraw 笔记添加后缀.excalidraw 等 [^1]，给笔记添加文件的创建时间 (YYYY-MM-DD_) 的前缀，统一附件 (图片) 格式等等操作，也是我为了图方便制作的脚本。
+
+> [!caution]+ 警告
+> 对脚本不熟悉的人，请慎重操作，⚠一定要备份好自己的数据！
+
+### obsidian bulk rename 插件
+
+Obsidian 插件市场有批量重命名操作的插件：obsidian bulk rename，我这属于重复造轮子了。
+
+## 操作过程及设计思路
+
+### 重命名
+
+对文件的重命名是利用的 Obsidian 的自带的重命名 API，相当于你手动在 Obsidian 重命名操作一样，关联的笔记会自动更新：
+
+```js
+/**
+ * Rename or move a file safely, and update all links to it depending on the user's preferences.
+ * @param file - the file to rename
+ * @param newPath - the new path for the file
+ * @public
+ */
+await app.fileManager.renameFile(file: TAbstractFile, newPath: string)
+```
+
+> 支持的对象有：笔记 (md、canvas)、附件 (png、jpg……)、文件夹
+
+### 搜索和替换
+
+批量重命名前的重点是准确的搜索定位以及替换操作，就先从这里开始说明
+
+#### Obsidian 搜索
+
+采用的 Obsidian 的搜索结果来获取需要批量操作的文件，需要复制带有路径的搜索结果：
+
+![2024-03-03_QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹)_IMG-1](https://cdn.pkmer.cn/images/202403160212435.png!pkmer)
+
+> [!tip] Obsidian 搜索功能
+> Obsidian 自带的搜索功能非常强，可以按文件名 file，路径 path，标签 tag 等检索方式相互组合，但本文主要介绍重命名操作，这里就不详细介绍了，具体可参考官方文档 [Search - Obsidian Help](https://help.obsidian.md/Plugins/Search) 或者 PKMer 内的相关教程。
+> ![2024-03-03_QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹)_IMG-2](https://cdn.pkmer.cn/images/202403160212436.png!pkmer)
+
+#### 正则替换
+
+除了简单的一些标点符号或者字符串的替换，我们还往往存在比较复杂格式需要替换，就会采取正则替换的方法，这里推荐一个非常好用的正则替换可视化的在线网址：[regex101](https://regex101.com/)。
+
+![2024-03-03_QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹)_IMG-3](https://cdn.pkmer.cn/images/202403160212437.png!pkmer)
+
+同样正则语法我也不详细介绍了，可以到 [正则表达式|菜鸟教程](https://www.runoob.com/regexp/regexp-tutorial.html) 了解并学习下。
+
+### 原文件名➡新文件名
+
+在 regex101 中修改完后，我们就获取了**原文件名**和**新文件名**2 组数据了，这时候就可以启用该脚本，首先启动后会依次弹出🟢原文件名、🟡新文件名的输入框，将我们的数据放入文本框即可，即以🟢原文件名➡🟡新文件名的形式改变的名称：
+
+![2024-03-03_QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹)_IMG-4](https://cdn.pkmer.cn/images/202403160212439.png!pkmer)
+
+### 确认或取消替换
+
+保险起见，在这之后会显示重名的结果 (🟢原文件名➡🟡新文件名)，可以取消个别文件的重命名，**Submit** 提交之后就会开始重命名了：
+
+![2024-03-03_QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹)_IMG-5](https://cdn.pkmer.cn/images/202403160212440.png!pkmer)
+
+> [!caution] 🔴批量操作前一定要注意备份数据！
+> 1. 一定要备份好自己的数据！！！
+> 2. 一定要备份好自己的数据！！！
+> 3. 一定要备份好自己的数据！！！
+
+### 日志文件
+
+重命名完成后会生成一个 RenameChangeLog.md 的日志文件，默认在根目录：
+
+![2024-03-03_QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹)_IMG-6](https://cdn.pkmer.cn/images/202403160212441.png!pkmer)
+
+#### 撤销上一步操作
+
+如果想撤销上一步操作，在 RenameChangeLog 文件中将 `♻newFilePaths` 作为 `🟢原文件名`，`🕓oldFilePaths` 作为 `🟡新文件名` 来操作，即：`♻newFilePaths➡🕓oldFilePaths`
+
+#### 设置日志路径
+
+如果想切换位置请在 QuickAdd 里面进行设置，注意嵌套文件使用 `/` 分隔：
+
+![2024-03-03_QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹)_IMG-7](https://cdn.pkmer.cn/images/202403160212442.png!pkmer)
+
+具体操作如下所示：
+
+![2024-03-03_QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹)_IMG-8](https://cdn.pkmer.cn/images/202403160212443.gif!pkmer)
+
+## 系统外部操作
+
+该脚本支持绝对路径的替换，即你在系统外复制文件路径并修改后也可以进行操作，这里我是借助专业软件 (eg:ReNamer) 在系统文件夹中重命名，这样不仅支持正则替换，还支持排序，插入文件的创建时间等等更加复杂重命了：
+
+![2024-03-03_QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹)_IMG-9](https://cdn.pkmer.cn/images/202403160212444.png!pkmer)
+
+### 复制结果
+
+用软件修改后，需要显示原始路径和新路径，操作如下，右键下拉菜单中勾选 `路径` 和 `新路径`：
+
+![2024-03-03_QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹)_IMG-10](https://cdn.pkmer.cn/images/202403160212445.png!pkmer)
+
+复制结果到剪切板：
+
+![2024-03-03_QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹)_IMG-11](https://cdn.pkmer.cn/images/202403160212446.png!pkmer)
+
+粘贴到 Excel 表格里面，就可以获取到原始路径和新路径的结果了：
+
+![2024-03-03_QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹)_IMG-12](https://cdn.pkmer.cn/images/202403160212447.png!pkmer)
+
+接下来的操作就一样了：
+
+![2024-03-03_QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹)_IMG-13](https://cdn.pkmer.cn/images/202403160212448.png!pkmer)
+
+## QuickAdd Macro 脚本
+
+```js
+const path = require("path");
+// 在Obsidian中导入QuickAdd的API
+const quickaddApi = app.plugins.plugins.quickadd.api;
+
+module.exports = {
+    entry: async (QuickAdd, settings, params) => {
+        // 输入界面
+        const oldFileNames = await quickaddApi.wideInputPrompt("🟢原文件名", "注意文件路径必须要有后缀");
+        if (!oldFileNames) return;
+        const newFileNames = await quickaddApi.wideInputPrompt("🟡新文件名", "注意文件路径必须要有后缀");
+
+        let oldFileNamesArray = oldFileNames.split("\n");
+        let newFileNamesArray = newFileNames.split("\n");
+
+        // 获取库的基本路径
+        const basePath = (app.vault.adapter).getBasePath().replace(/\\/g, '/');
+        //  转义路径中的反斜杠为斜杠 去除数组中包含库的基本路径
+        oldFileNamesArray = oldFileNamesArray.map(fileName => fileName.replace(/\\/g, '/').replace(`${basePath}/`, ''));
+        newFileNamesArray = newFileNamesArray.map(fileName => fileName.replace(/\\/g, '/').replace(`${basePath}/`, ''));
+        if (oldFileNamesArray.length !== newFileNamesArray.length) return;
+
+        const changeItems = oldFileNamesArray.map((oldFileName, index) => {
+            const oldFileNameWithoutPath = path.basename(oldFileName);
+            const newFileNameWithoutPath = path.basename(newFileNamesArray[index]);
+            return `${oldFileNameWithoutPath}⏩${newFileNameWithoutPath}`;
+        });
+
+        // 重新检查一下
+        let selectedItems = [];
+        selectedItems = await quickaddApi.checkboxPrompt(changeItems, changeItems);
+        if (!selectedItems) return;
+        console.log(selectedItems);
+
+        const selectedIndexes = selectedItems.map(item => {
+            const oldFileNameWithoutPath = item.split('⏩')[0];
+            return oldFileNamesArray.findIndex(newFileName => path.basename(newFileName) === oldFileNameWithoutPath);
+        }).filter(index => index !== -1);
+
+        console.log(selectedIndexes);
+
+        oldFileNamesArray = selectedIndexes.map(index => oldFileNamesArray[index]);
+        newFileNamesArray = selectedIndexes.map(index => newFileNamesArray[index]);
+
+        let changeOldFiles = [];
+        let changeNewFiles = [];
+        // 记录报错的文档路径到 bugFilePaths
+        let bugFilePaths = [];
+
+        for (let i = 0; i < oldFileNamesArray.length; i++) {
+            const oldFileName = oldFileNamesArray[i];
+            const newFileName = newFileNamesArray[i];
+            console.log([oldFileName, newFileName]);
+            if (oldFileName === newFileName) continue;
+            // 如果app.fileManager.renameFile报错请continue，并报出 oldFileName 以及对应的错误，应该是库中文件名有重复的了
+            try {
+                await app.fileManager.renameFile(app.vault.getAbstractFileByPath(oldFileName), newFileName);
+                changeOldFiles.push(oldFileName);
+                changeNewFiles.push(newFileName);
+            } catch (error) {
+                new Notice(`❌${oldFileName}重命名出现错误，已记录到Log\n\n${error}\n\n`);
+                bugFilePaths.push(oldFileName);
+                continue;
+            }
+        }
+
+        // 生成记录的markdown的RenameChangeLog.md，记录到 bugFilePaths
+        const timstamp = quickaddApi.date.now("YYYY-MM-DD_HH-mm");
+        const logContent = `## ${timstamp}\n\n### ❌bugFilePaths\n\n\`\`\`\n${bugFilePaths.join("\n")}\n\`\`\`\n\n### 🕓oldFilePaths\n\n\`\`\`\n${changeOldFiles.join("\n")}\n\`\`\`\n\n### ♻newFilePaths\n\n\`\`\`\n${changeNewFiles.join("\n")}\n\`\`\`\n\n`;
+
+        // ! 配置RenameChangeLo路径
+        let renameLogPath = settings["RenameChangeLogPath"];
+        let file = app.vault.getAbstractFileByPath(renameLogPath);
+        if (file) {
+            await app.vault.append(file, logContent);
+        } else {
+            await app.vault.create(renameLogPath, logContent);
+        }
+        new Notice("✅替换完成");
+    },
+    settings: {
+        name: "Obsidian-Bulk-Rename",
+        author: "熊猫别熬夜",
+        options: {
+            "RenameChangeLogPath": {
+                type: "text",
+                defaultValue: "RenameChangeLog.md",
+                description: "设置批量重命名修改记录文件路径，嵌套文件夹请用/符号",
+            },
+        }
+    },
+};�
+```

--- a/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-Project项目选项栏.md
+++ b/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-Project项目选项栏.md
@@ -1,0 +1,48 @@
+---
+uid: 20240311175436
+title: QuickAdd 脚本 -Project 项目选项栏
+tags: [Project, quickadd脚本]
+description: Project 项目选项栏
+author: 熊猫别熬夜
+type: other
+draft: false
+editable: false
+modified: 20240311180921
+---
+
+# QuickAdd 脚本 -Project 项目选项栏
+
+## 背景
+
+当使用 Project 插件时，只能设置一个默认的项目视图，其他项目视图需要手动切换或者在插件里面添加快捷指令，之后设置 Button 或者 Advanced URI 来的便捷打开指定的 Project 项目。
+
+为了不用单独建一个页面来存放这些按钮，就采用 JS 获取 Project 的快捷指令，出现一个下拉选项，这样不用单独设置按钮了，通过下拉菜单选择指定项目来跳转。
+
+![2024-03-08_QuickAdd脚本-Project项目选项栏_IMG-1](https://cdn.pkmer.cn/images/202403111756343.png!pkmer)
+
+> [!caution]+ 只会获取 Project 已勾选的的项目
+> ![2024-03-08_QuickAdd脚本-Project项目选项栏_IMG-2](https://cdn.pkmer.cn/images/202403111756344.png!pkmer)
+
+## 代码
+
+```js quickadd
+const projeckIds = Object.keys(app.commands.commands)
+    .filter(key => key.includes("obsidian-projects:show:"));
+const projeckNames = ProjectCommands.map(i => app.commands.commands[i].name);
+
+const quickAddApi = app.plugins.plugins.quickadd.api;
+const id = await quickAddApi.suggester(projeckNames, projeckIds);
+app.commands.executeCommandById(id);
+```
+
+可用 QuickAdd 的 Marco 或者 Capture 来调用
+
+### Quickadd 配置 Macro
+
+将下述脚本放在 Quickadd 的配置文件夹下，保存为 `ShowProjects.js` 文件，在 Quickadd 插件设置添加 Macro 动作，注意设置名称：
+
+![2024-03-08_QuickAdd脚本-Project项目选项栏_IMG-3](https://cdn.pkmer.cn/images/202403111756345.png!pkmer)
+
+在 Scripts 中选择对应的 `ShowProjects.js` 脚本，点击添加即可：
+
+![2024-03-08_QuickAdd脚本-Project项目选项栏_IMG-4](https://cdn.pkmer.cn/images/202403111756346.gif!pkmer)

--- a/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-Project项目选项栏.md
+++ b/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-Project项目选项栏.md
@@ -26,13 +26,15 @@ modified: 20240311180921
 ## 代码
 
 ```js quickadd
-const projeckIds = Object.keys(app.commands.commands)
-    .filter(key => key.includes("obsidian-projects:show:"));
-const projeckNames = ProjectCommands.map(i => app.commands.commands[i].name);
+module.exports = async (params) => {
+    const projeckIds = Object.keys(app.commands.commands)
+        .filter(key => key.includes("obsidian-projects:show:"));
+    const projeckNames = projeckIds.map(i => app.commands.commands[i].name);
 
-const quickAddApi = app.plugins.plugins.quickadd.api;
-const id = await quickAddApi.suggester(projeckNames, projeckIds);
-app.commands.executeCommandById(id);
+    const quickAddApi = app.plugins.plugins.quickadd.api;
+    const id = await quickAddApi.suggester(projeckNames, projeckIds);
+    app.commands.executeCommandById(id);
+};
 ```
 
 可用 QuickAdd 的 Marco 或者 Capture 来调用

--- a/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-利用Canvas平铺笔记.md
+++ b/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-利用Canvas平铺笔记.md
@@ -7,32 +7,18 @@ author: 熊猫别熬夜
 type: other
 draft: false
 editable: false
-modified: 20240222233822
+modified: 20240311182455
 ---
 
 # QuickAdd 脚本 - 利用 Canvas 平铺笔记
 
+## 前言
+
 在 Obsidian 中文论坛看到这篇 [在Excalidraw中列出某笔记所有二级Heading - 经验分享 - Obsidian 中文论坛](https://forum-zh.obsidian.md/t/topic/30401) ，我就想用 Canvas 来平铺一下，这样笔记可以全局预览和编辑。
-
-## Canvas 的标题引用格式
-
-Canvas 是可以只显示文档的块和标题的，具体格式如下，标题是在 `subpath` 中且前面有个 `#` 号。
-
-```json
-{
-	"nodes":[
-		{"id":"d9f2b88a08cb0f1c","type":"file","file":"QuickDraft-20240221200235533.md","subpath":"#PkmerFAQ","x":-447,"y":-333,"width":960,"height":760},
-		{"id":"6b050e9a6fa81b69","type":"file","file":"QuickDraft-20240221200235533.md","subpath":"#PkmerDocs","x":560,"y":-333,"width":960,"height":760},
-		{"id":"454248a7b980b488","type":"file","file":"QuickDraft-20240221200235533.md","subpath":"#Fix","x":1580,"y":-333,"width":960,"height":760},
-		{"id":"207cfe3dd7b01f03","type":"file","file":"QuickDraft-20240221200235533.md","subpath":"#Fix","x":-447,"y":500,"width":960,"height":760}
-	],
-	"edges":[]
-}
-```
 
 ## 实现过程和效果
 
-![2024-02-21_QuickAdd脚本-利用Canvas平铺笔记_IMG-1](https://cdn.pkmer.cn/images/202402230946313.gif!pkmer)
+![2024-02-21_QuickAdd脚本-利用Canvas平铺笔记_IMG-1](https://cdn.pkmer.cn/images/202403111759579.gif!pkmer)
 
 - 获取当前笔记路径
 	- 提取所有标题 (可选范围，即标题参数)，暂定二级标题
@@ -42,33 +28,17 @@ Canvas 是可以只显示文档的块和标题的，具体格式如下，标题�
 
 我是固定一个 Canvas 用来编辑，我这边直接随便设置的一个 `未命名.canvas`，可以 2 种模式可以相互转换，转换的参数通过代码参数来调节。
 
-### 可调整的参数
-
-```js
-// 大纲等级
-const level = 2;
-// 卡片参数
-const width = 960;
-const height = 760;
-// 卡片间隔
-const space = 50;
-// 每行卡片的数量限制
-const limit = 4;
-// 基于库的相对路径的Canvas
-const canvasPath = "未命名.canvas"; 
-```
-
 ## Quickadd 配置 Macro 代码
 
 将下述脚本放在 Quickadd 的配置文件夹下，保存为 `convertMdToCanvas.js` 文件，在 Quickadd 插件设置添加 Macro 动作：
 
-![2024-02-21_QuickAdd脚本-利用Canvas平铺笔记_IMG-2](https://cdn.pkmer.cn/images/202402230946314.png!pkmer)
+![2024-02-21_QuickAdd脚本-利用Canvas平铺笔记_IMG-2](https://cdn.pkmer.cn/images/202403111759581.png!pkmer)
 
 在 Scripts 中选择对应的 `convertMdToCanvas` 脚本，点击添加即可：
 
-![2024-02-21_QuickAdd脚本-利用Canvas平铺笔记_IMG-3](https://cdn.pkmer.cn/images/202402230946315.png!pkmer)
+![2024-02-21_QuickAdd脚本-利用Canvas平铺笔记_IMG-3](https://cdn.pkmer.cn/images/202403111759582.png!pkmer)
 
-### 脚本
+### QuickAdd Macro 脚本
 
 ```js
 const path = require('path');
@@ -77,331 +47,178 @@ const fs = require('fs');
 const file = app.workspace.getActiveFile();
 const fileFullPath = app.vault.adapter.getFullPath(file.path);
 
-// 可调节的参数
-// 大纲等级
-const level = 2;
-// 卡片参数
-const width = 960;
-const height = 760;
-// 卡片间隔
-const space = 50;
-// 每行卡片的数量限制
-const limit = 3;
-// 基于库的相对路径的Canvas
-const canvasPath = "未命名.canvas";
-
-module.exports = async () => {
-    const canvasData = {
-        nodes: [],
-        edges: []
-    };
-    if (file.extension === 'md') {
-        console.log("开始获取二级标题");
-        const heads = getHeadings(fileFullPath, level);
-        console.log(heads);
-
-        let x = 0;
-        let y = 0;
-        let n = 1;
-        let nodes = [];
-        const length = heads.length;
-
-        for (let i = 1; i <= length; i++) {
-            const node = {
-                id: "",
-                type: "file",
-                file: file.path,
-                subpath: "",
-                x: 0,
-                y: 0,
-                width: width,
-                height: height,
-            };
-
-            node.subpath = heads[i - 1];
-            node.id = i;
-            node.x = x;
-            node.y = y;
-            console.log([heads[i - 1], x, y]);
-
-            x += width + space;
-            if (i >= limit * n) {
-                y += height + space;
-                x = 0;
-                n = n + 1;
-            }
-            console.log([heads[i - 1], node.x, y]);
-
-            nodes.push(node);
-        }
-        canvasData.nodes = nodes;
-        console.log(canvasData);
-        const canvasFile = app.vault.getAbstractFileByPath(canvasPath);
-        const canvasJson = JSON.stringify(canvasData, null, 2);
-        if (canvasFile) {
-            app.vault.modify(canvasFile, canvasJson);
-        } else {
-            canvasFile = app.vault.create(canvasPath, canvasJson);
-        }
-        app.workspace.activeLeaf.openFile(canvasFile);
-
-    } else if (file.extension === 'canvas') {
-        fs.readFile(fileFullPath, 'utf8', (err, data) => {
-            if (err) throw err;
-            const canvasData = JSON.parse(data);
-            // 获取nodes中的object.file
-            canvasData.nodes;
-            const mdFilePath = canvasData.nodes[0].file;
-            app.workspace.activeLeaf.openFile(app.vault.getAbstractFileByPath(mdFilePath));
-        });
-
-    }
-
-};
-
-
-function getHeadings(fileFullPath, level) {
-    // 读取文件内容
-    const fileContent = fs.readFileSync(fileFullPath, 'utf-8');
-
-    // 使用正则表达式提取指定级别的标题
-    const regex = new RegExp(`^#{2,${level}}\\s(.+)`, 'gm');
-    const matches = [];
-    let match;
-
-    while ((match = regex.exec(fileContent)) !== null) {
-        matches.push("#" + match[1]);
-    }
-    return matches;
-}
-```
-
-## 配合 Modal Form 插件来调节参数
-
-![2024-02-21_QuickAdd脚本-利用Canvas平铺笔记_IMG-4](https://cdn.pkmer.cn/images/202402230946316.png!pkmer)
-
-> 配合 ModalForm 插件写了个表单，可以设置参数，不过体验下来，还不如提前把参数设置好一键切换来的方便，还不需要额外安装插件。
-
-### 脚本
-
-配置同上述一样，不过需要安装 Modal Form 插件
-
-```js
-
-// 基于库的相对路径的Canvas
-const canvasPath = "未命名.canvas";
-
-const path = require('path');
-const fs = require('fs');
-const modalForm = app.plugins.plugins.modalforms.api;
-// 获取笔记的基本路径
-const file = app.workspace.getActiveFile();
-const fileFullPath = app.vault.adapter.getFullPath(file.path);
-
-
-module.exports = async () => {
-
-    const editorForm1 = {
-        "title": "ConvertMdToCanvas",
-        "name": "ConvertMdToCanvas",
-        "fields": [
-            {
-                "name": "level",
-                "label": "level",
-                "description": "提取至第几级标题，忽略一级标题",
-                "input": {
-                    "type": "slider",
-                    "min": 2,
-                    "max": 6
-                }
-            },
-            {
-                "name": "width",
-                "label": "Width",
-                "description": "卡片宽度",
-                "isRequired": true,
-                "input": {
-                    "type": "number"
-                }
-            },
-            {
-                "name": "height",
-                "label": "height",
-                "description": "卡片高度",
-                "isRequired": true,
-                "input": {
-                    "type": "number"
-                }
-            },
-            {
-                "name": "space",
-                "label": "space",
-                "description": "卡片间距",
-                "isRequired": true,
-                "input": {
-                    "type": "number"
-                }
-            },
-            {
-                "name": "limit",
-                "label": "limit",
-                "description": "每行卡片的数量限制",
-                "input": {
-                    "type": "slider",
-                    "min": 1,
-                    "max": 10
-                }
-            },
-        ]
-    };
-    const canvasData = {
-        nodes: [],
-        edges: []
-    };
-    if (file.extension === 'md') {
-        // 设定默认值
-        let result = await modalForm.openForm(
-            editorForm1,
-            {
-                values: {
-                    level: 2,
-                    width: 960,
-                    height: 760,
-                    limit: 4,
-                    space: 50,
-                }
-            }
-        );
-
-
+module.exports = {
+    entry: async (QuickAdd, settings, params) => {
+        // 可调节的参数
         // 大纲等级
-        const level = result.getValue('level').value;
+        const level = Number(settings["level"]);
         // 卡片参数
-        const width = result.getValue('width').value;
-        const height = result.getValue('height').value;
+        const width = Number(settings["width"]);
+        const height = Number(settings["height"]);
         // 卡片间隔
-        const space = result.getValue('space').value;
+        const space = Number(settings["space"]);
         // 每行卡片的数量限制
-        const limit = result.getValue('limit').value;
+        const limit = Number(settings["limit"]);
+        // 基于库的相对路径的Canvas
+        const canvasPath = settings["canvasPath"];
 
-        console.log("开始获取二级标题");
-        const heads = getHeadings(fileFullPath, level);
-        console.log(heads);
+        const canvasData = {
+            nodes: [],
+            edges: []
+        };
+        if (file.extension === 'md') {
+            console.log("开始获取二级标题");
+            const { heads, counts } = getHeadings(fileFullPath, level);
+            console.log(heads);
 
-        let x = 0;
-        let y = 0;
-        let n = 1;
-        let nodes = [];
-        const length = heads.length;
+            let x = 0;
+            let y = 0;
+            let n = 1;
+            let nodes = [];
+            const length = heads.length;
 
-        for (let i = 1; i <= length; i++) {
-            const node = {
-                id: "",
-                type: "file",
-                file: file.path,
-                subpath: "",
-                x: 0,
-                y: 0,
-                width: width,
-                height: height,
-            };
+            for (let i = 1; i <= length; i++) {
+                const node = {
+                    id: "",
+                    type: "file",
+                    file: file.path,
+                    subpath: "",
+                    x: 0,
+                    y: 0,
+                    width: width,
+                    height: height,
+                };
 
-            node.subpath = heads[i - 1];
-            node.id = i;
-            node.x = x;
-            node.y = y;
-            console.log([heads[i - 1], x, y]);
+                node.subpath = heads[i - 1];
+                node.id = String(i);
+                node.x = x;
+                node.y = y;
+                node.color = String(counts[i - 1]-1)
+                console.log([heads[i - 1], x, y]);
 
-            x += width + space;
-            if (i >= limit * n) {
-                y += height + space;
-                x = 0;
-                n = n + 1;
+                x += width + space;
+                if (i >= limit * n) {
+                    y += height + space;
+                    x = 0;
+                    n = n + 1;
+                }
+                console.log([heads[i - 1], node.x, y]);
+
+                nodes.push(node);
             }
-            console.log([heads[i - 1], node.x, y]);
+            canvasData.nodes = nodes;
+            console.log(canvasData);
+            const canvasFile = app.vault.getAbstractFileByPath(canvasPath);
+            const canvasJson = JSON.stringify(canvasData, null, 2);
+            if (canvasFile) {
+                app.vault.modify(canvasFile, canvasJson);
+                app.workspace.activeLeaf.openFile(canvasFile);
+            } else {
+                canvasFile = app.vault.create(canvasPath, canvasJson);
+                app.workspace.activeLeaf.openFile(canvasFile);
+            }
 
-            nodes.push(node);
+            // 尝试重新加载缩略图
+            setTimeout(() => {
+                try {
+                    app.commands.executeCommandById("canvas-minimap:reload");
+                } catch (error) {
+                    console.log(error);
+                }
+            }, 1000);
+
+
+        } else if (file.extension === 'canvas') {
+            fs.readFile(fileFullPath, 'utf8', (err, data) => {
+                if (err) throw err;
+                const canvasData = JSON.parse(data);
+                // 获取nodes中的object.file
+                canvasData.nodes;
+                const mdFilePath = canvasData.nodes[0].file;
+                app.workspace.activeLeaf.openFile(app.vault.getAbstractFileByPath(mdFilePath));
+            });
+
         }
-        canvasData.nodes = nodes;
-        console.log(canvasData);
-        const canvasFile = app.vault.getAbstractFileByPath(canvasPath);
-        const canvasJson = JSON.stringify(canvasData, null, 2);
-        if (canvasFile) {
-            app.vault.modify(canvasFile, canvasJson);
-        } else {
-            canvasFile = app.vault.create(canvasPath, canvasJson);
+
+    },
+    settings: {
+        name: "Convert md to canvas",
+        author: "熊猫别熬夜",
+        options: {
+            "canvasPath": {
+                type: "text",
+                defaultValue: "MdToCanvas.canvas",
+                placeholder: "相对路径",
+                description: "设置Canvas路径，可以嵌套子文件夹",
+            },
+            "level": {
+                type: "dropdown",
+                defaultValue: 2,
+                options: [2, 3, 4, 5, 6],
+                description: "设置平铺的大纲等级，每个等级对应不同颜色",
+            },
+            "width": {
+                type: "text",
+                defaultValue: "1080",
+                placeholder: "卡片参数",
+                description: "卡片宽度",
+
+            },
+            "height": {
+                type: "text",
+                defaultValue: "1000",
+                placeholder: "卡片参数",
+                description: "卡片高度",
+            },
+
+            "limit": {
+                type: "text",
+                defaultValue: "3",
+                placeholder: "每行卡片数量",
+                description: "每行卡片数量",
+            },
+            "space": {
+                type: "text",
+                defaultValue: "250",
+                placeholder: "卡片间隔",
+                description: "卡片之间的间隔",
+
+            },
         }
-        app.workspace.activeLeaf.openFile(canvasFile);
-
-    } else if (file.extension === 'canvas') {
-        fs.readFile(fileFullPath, 'utf8', (err, data) => {
-            if (err) throw err;
-            const canvasData = JSON.parse(data);
-            // 获取nodes中的object.file
-            canvasData.nodes;
-            const mdFilePath = canvasData.nodes[0].file;
-            app.workspace.activeLeaf.openFile(app.vault.getAbstractFileByPath(mdFilePath));
-        });
-
     }
 
-
 };
+
 
 function getHeadings(fileFullPath, level) {
     // 读取文件内容
     const fileContent = fs.readFileSync(fileFullPath, 'utf-8');
-
     // 使用正则表达式提取指定级别的标题
     const regex = new RegExp(`^#{2,${level}}\\s(.+)`, 'gm');
-    const matches = [];
-    let match;
+    const heads = [];
+    let head;
+    let counts = [];
 
-    while ((match = regex.exec(fileContent)) !== null) {
-        matches.push("#" + match[1]);
+    while ((head = regex.exec(fileContent)) !== null) {
+        heads.push("#" + head[1]);
+        counts.push(head[0].match(/#/g).length);
     }
-    return matches;
+    return { heads, counts };
 }
+
 ```
 
-## Quickadd 配置 Capture
+## 可调整的参数
 
-![2024-02-21_QuickAdd脚本-利用Canvas平铺笔记_IMG-5](https://cdn.pkmer.cn/images/202402230946317.png!pkmer)
+![2024-02-21_QuickAdd脚本-利用Canvas平铺笔记_IMG-4](https://cdn.pkmer.cn/images/202403111759583.gif!pkmer)
 
-### 脚本
+![2024-02-21_QuickAdd脚本-利用Canvas平铺笔记_IMG-5](https://cdn.pkmer.cn/images/202403111759584.jpg!pkmer)
 
-该代码由 Obsidian 中文论坛的 PlayerMiller 提供，来源于：<https://forum-zh.obsidian.md/t/topic/30401/11>
+## 配合 Canvas Minimal 插件
 
-````md
-```js quickadd
-const fs = require('fs'), getFBP = path => app.vault.getAbstractFileByPath(path), getHeadings = (vFPath, lv) => {
-    let fileContent = fs.readFileSync(vFPath, 'utf-8'), regex = new RegExp(`^#{2,${lv}} (.+)`, 'gm')
-        , mats = [], mat; while ((mat = regex.exec(fileContent)) !== null) mats.push(`#${mat[1]}`); return mats;
-}
-    , file = app.workspace.getActiveFile(), vFPath = app.vault.adapter.getFullPath(file.path), cvsData = { nodes: [], edges: [] }
-    , lv = 2, width = 960, height = 760, space = 50, limit = 4, cvsPath = '未命名.canvas'; // 参数行
-switch (file.extension) {
-    case 'md': let heads = getHeadings(vFPath, lv), x = 0, y = 0, n = 1, nodes = [];
-        for (let i = 1; i <= heads.length; i++) {
-            let node = { id: '', type: 'file', file: file.path, subpath: '', x: 0, y: 0, width: width, height: height };
-            node.subpath = heads[i - 1]; node.id = i; node.x = x; node.y = y; x += width + space;
-            if (i >= limit * n) { y += height + space; x = 0; n += 1; }; nodes.push(node);
-        }; cvsData.nodes = nodes; let cvsFile = getFBP(cvsPath), cvsJson = JSON.stringify(cvsData, null, 2);
-        if (cvsFile) { app.vault.modify(cvsFile, cvsJson); } else cvsFile = await app.vault.create(cvsPath, cvsJson);
-        app.workspace.activeLeaf.openFile(cvsFile); break;
-    case 'canvas': fs.readFile(vFPath, 'utf8', (err, data) => {
-        if (err) throw err; let mdFilePath = JSON.parse(data).nodes[0].file;
-        app.workspace.activeLeaf.openFile(getFBP(mdFilePath));
-    }); break;
-}
-```
-````
+另外推荐 [Canvas Minimal](https://github.com/ifree/Obsidian-canvas-minimap)，可以给 Canvas 生成缩略图并点击可跳转。
 
-## 拓展想法
-
-如果确定每个标题的格式 (如：草稿、提示、总结)，是否可以按照康奈尔笔记布局一样生成对应的 Canvas 来编辑：
-
-![2024-02-21_QuickAdd脚本-利用Canvas平铺笔记_IMG-6](https://cdn.pkmer.cn/images/202402230946318.png!pkmer)
+![2024-02-21_QuickAdd脚本-利用Canvas平铺笔记_IMG-6](https://cdn.pkmer.cn/images/202403111759585.gif!pkmer)
 
 ## References
 

--- a/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-复制wiki对应文档内容并删除文件.md
+++ b/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-复制wiki对应文档内容并删除文件.md
@@ -1,0 +1,95 @@
+---
+uid: 20240316224647
+title: QuickAdd脚本-复制wiki对应文档内容并删除文件
+tags:
+  - 工作流
+  - quickadd脚本
+  - 文件重构
+description: 复制 wiki 对应文档内容并删除文件，适用于快速将子笔记内容整理到剪切板，以及删除子文档的操作。
+author: 熊猫别熬夜
+type: other
+draft: false
+editable: false
+modified: 20240316224811
+---
+
+# QuickAdd 脚本 - 复制 wiki 对应文档内容并删除文件
+
+该脚本的功能是复制通过鼠标选中的 `[[]]` 文本，然后将对应文档的内容（不包括 Yaml）复制到剪贴板，并删除该文档。
+
+![2024-03-13_QuickAdd脚本-复制wiki对应文档内容并删除文件_IMG-1](https://cdn.pkmer.cn/images/202403162248665.gif!pkmer)
+
+适用于快速将子笔记内容整理到剪切板，以及删除子文档的操作。
+
+## QuickAdd Macro 设置
+
+![2024-03-13_QuickAdd脚本-复制wiki对应文档内容并删除文件_IMG-2](https://cdn.pkmer.cn/images/202403162248667.png!pkmer)
+
+第一个命令 `1. Select link on active line` 在 Add editor command 的下拉菜单找，然后配置下面的脚本，即将下面代码复制到 js 文件 (如：`复制并删除文件.js`) 中，并存放到 QuickAdd 对应的脚本文件夹下，即可在 User Scripts 里面找到并添加。
+
+### 脚本
+
+```js
+const fs = require('fs');
+const path = require('path');
+const process = require('process');
+
+module.exports = async (params) => {
+    // 获取选中的文本
+    const selection = getSelection().toString(); // 将 selection 转换为字符串
+    let selectionEmbed = matchSelectionEmbed(selection);
+    console.log(selectionEmbed);
+    const files = app.vault.getFiles();
+
+    // Wiki: 获取库所有文件列表
+    wikiPath = getFilePath(files, selectionEmbed); // 匹配Wiki链接
+    console.log(wikiPath);
+    if (!wikiPath) {
+        new Notice("❌未找到对应文件");
+        return;
+    };
+
+    let markdownText = getMarkdownText(wikiPath);
+
+    // 复制并删除文件
+    copyToClipboard(markdownText);
+    await app.vault.trash(app.vault.getAbstractFileByPath(wikiPath));
+    new Notice("💡已复制内容到剪切板，并删除文件");
+    return;
+};
+
+function matchSelectionEmbed(text) {
+    const regex = /\[\[(.*)\]\]/;
+    const matches = text.match(regex);
+    return matches ? matches[1] : "";
+}
+function getFilePath(files, baseName) {
+    let files2 = files.filter(f => path.basename(f.path).replace(".md", "") === baseName.replace(".md", ""));
+    let filePath = files2.map((f) => f.path);
+    return filePath[0];
+}
+
+function copyToClipboard(extrTexts) {
+    const txtArea = document.createElement('textarea');
+    txtArea.value = extrTexts;
+    document.body.appendChild(txtArea);
+    txtArea.select();
+    if (document.execCommand('copy')) {
+        console.log('copy to clipboard.');
+    } else {
+        console.log('fail to copy.');
+    }
+    document.body.removeChild(txtArea);
+}
+
+// 获取文件路径下的 md 中的文本(排除 Yaml)
+function getMarkdownText(filePath) {
+    // 获取文件的完整路径
+    const fileFullPath = app.vault.adapter.getFullPath(filePath);
+    // 读取文件内容
+    const fileContent = fs.readFileSync(fileFullPath, 'utf8');
+    // 排除首行YAML区域
+    const markdownText = fileContent.replace(/---[\s\S]*?---\n*/, '').replace(/\n*/, '');
+    return markdownText;
+}
+```

--- a/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-配合FolderNotes及Markmind插件生成文件大纲导图.md
+++ b/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-配合FolderNotes及Markmind插件生成文件大纲导图.md
@@ -1,0 +1,162 @@
+---
+uid: 20240316224305
+title: QuickAdd 脚本 - 配合 FolderNotes 及 Markmind 插件生成文件大纲导图
+tags: [quickadd脚本, 文件夹管理, 思维导图]
+description: " 配合 FolderNotes 及 Markmind 插件生成文件大纲导图"
+author: 熊猫别熬夜
+type: other
+draft: false
+editable: false
+modified: 20240316224519
+---
+
+# QuickAdd 脚本 - 配合 FolderNotes 及 Markmind 插件生成文件大纲导图
+
+## 背景
+
+![2024-03-13_QuickAdd脚本-配合FolderNotes及Markmind插件生成文件大纲导图_IMG-1](https://cdn.pkmer.cn/images/202403162247188.png!pkmer)
+
+需求来源于一个群友 [^1] 对文件夹想要以思维导图的形式展开，我个人最近开始采用杜威十进制来给文件夹加编号以及一直以来都是用 Folder Notes 插件 (作者：Lost Paul)，对这个话题就比较感兴趣，尝试做了一下，用 js 自动检测生成一个 Obsidian index 的 FolderMind.md 文件，借助 Markmind 插件来显示思维导图，如果有 FolderNote 则会嵌入进去。
+
+## 脚本设置
+
+![2024-03-13_QuickAdd脚本-配合FolderNotes及Markmind插件生成文件大纲导图_IMG-2](https://cdn.pkmer.cn/images/202403162247190.png!pkmer)
+
+- 设置选项：
+	- 根目录大纲导图
+	- 当前 Root 文件夹大纲导图
+	- 当前 FolderNote 大纲导图
+- 可控制变量：
+	- folderMindPath：生成的 TreeFolderMind 的文件所在的位置，默认在根目录。
+	- maxDepth：文件夹检索深度 1~6 层；
+	- level：默认导图限制展开的深度，可调 1~5 级；
+	- ignoreFolders：忽略的文件夹表单，即不在导图中显示，不填路径只填文件夹名称。
+	- ignoreSubfoldersList：不进行进一步深度拓展的文件夹，不填路径只填文件夹名称，即分支到这节之后不会继续延伸。
+- 自动变量：
+	- 根据主题的深浅，生成的 Markmind 的主题不一样：
+		- 深色 (Cold)、浅色 (Warm)
+- 进阶需求：
+	- 根据导图移动方式来移动文件夹？
+	- 依据杜威十进制自动排序的机制？
+
+## QuickAdd Macro 脚本
+
+```js
+const fs = require('fs');
+const path = require('path');
+const folderPath = (app.vault.adapter).getBasePath();
+
+module.exports = {
+    entry: async (QuickAdd, settings, params) => {
+        const folderMindPath = settings["folderMindPath"];
+        const maxDepth = Number(settings["maxDepth"]);
+        const level = Number(settings["level"]);
+        const ignoreFolders = settings["ignoreFolders"].split(',');
+        console.log(ignoreFolders);
+        const ignoreSubfoldersList = settings["ignoreSubfoldersList"].split(',');
+        console.log(ignoreSubfoldersList);
+        const listPaths = traverseFolder(folderPath, '', ignoreFolders, ignoreSubfoldersList, maxDepth);
+        // console.log(listPaths);
+
+        // 设定固定Yaml
+
+        // 根据主题生成配色
+        const currentMode = app.vault.config.theme;
+        let mindmapTheme = "cold";
+        if (currentMode !== "obsidian") {
+            mindmapTheme = "warm";
+        }
+
+        const markmindYaml = `---\nmindmap-plugin: basic\nmindmap-theme: ${mindmapTheme}\ndisplay-mode: mind\n---\n`;
+        const text = markmindYaml + `# FolderMind\n` + listPaths.join("\n");
+
+        let mindFile = app.vault.getAbstractFileByPath(folderMindPath);
+
+        if (mindFile) {
+            app.vault.modify(mindFile, text);
+        } else {
+            mindFile = app.vault.create(folderMindPath, text);
+        }
+        app.workspace.activeLeaf.openFile(mindFile);
+        // await app.workspace.activeLeaf.rebuildView();
+        new Notice("文件夹导图生成成功！");
+
+        setTimeout(() => {
+            try {
+                app.commands.executeCommandById(`obsidian-markmind:Expand to node level ${level}`);
+            } catch (error) {
+                console.log(error);
+            }
+        }, 1000);
+
+    },
+    settings: {
+        name: "Tree Folder Mind",
+        author: "熊猫别熬夜",
+        options: {
+            "folderMindPath": {
+                type: "text",
+                defaultValue: "FolderNote.markmind.md",
+                placeholder: "相对路径",
+                description: "设置文件夹导图路径，可以嵌套子文件夹",
+            },
+            "maxDepth": {
+                type: "dropdown",
+                defaultValue: 3,
+                options: [1, 2, 3, 4, 5, 6],
+                description: "设置挖掘文件夹的深度",
+            },
+            "level": {
+                type: "dropdown",
+                defaultValue: 2,
+                options: [1, 2, 3, 4, 5],
+                description: "设置mind默认展开的深度",
+            },
+            "ignoreFolders": {
+                type: "text",
+                defaultValue: "@【熊阿莫】赞美太阳！",
+                placeholder: "忽略文件夹",
+                description: "设置忽略文件夹，多个用逗号隔开"
+            },
+            "ignoreSubfoldersList": {
+                type: "text",
+                defaultValue: "900【素材】Assets,510_Bookxnote库,700【模板】Template,550_CodeSnippet,540_图形文件存储",
+                description: "忽略某个文件夹下的子文件夹，即不展开，多个用逗号隔开"
+            }
+        }
+    }
+};
+
+function traverseFolder(folderPath, indent = '', ignoreFolders = [], ignoreSubfoldersList = [], maxDepth = 4, currentDepth = 1, listPaths = []) {
+    if (currentDepth > maxDepth) {
+        return listPaths;
+    }
+    const files = fs.readdirSync(folderPath);
+
+    files.forEach(file => {
+        const filePath = path.join(folderPath, file);
+        const stats = fs.statSync(filePath);
+
+        if (stats.isDirectory() && !file.startsWith('.') && !ignoreSubfoldersList.some(folder => filePath.includes(folder + "\\")) && !ignoreFolders.includes(file)) {
+            const fileName = path.basename(filePath);
+            const mocFile = `${filePath}/${fileName}.md`;
+            let mocNote = fs.existsSync(mocFile);
+            let listPath = "";
+            if (mocNote) {
+                listPath = indent + '- [[' + file + ']]';
+            } else {
+                listPath = indent + "- " + file;
+            }
+            console.log(listPath);
+            listPaths.push(listPath);
+
+            listPaths = traverseFolder(filePath, indent + '  ', ignoreFolders, ignoreSubfoldersList, maxDepth, currentDepth + 1, listPaths);
+        }
+    });
+
+    return listPaths;
+}
+
+```
+
+[^1]: 2024-03-13_ 文件夹展开的需求 by 吅

--- a/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-配合FolderNotes及Markmind插件生成文件大纲导图.md
+++ b/10-Obsidian/Obsidian社区插件/Quickadd/QuickAdd脚本-配合FolderNotes及Markmind插件生成文件大纲导图.md
@@ -7,7 +7,7 @@ author: 熊猫别熬夜
 type: other
 draft: false
 editable: false
-modified: 20240316224519
+modified: 20240317181510
 ---
 
 # QuickAdd 脚本 - 配合 FolderNotes 及 Markmind 插件生成文件大纲导图
@@ -38,6 +38,12 @@ modified: 20240316224519
 - 进阶需求：
 	- 根据导图移动方式来移动文件夹？
 	- 依据杜威十进制自动排序的机制？
+
+## 卡片布局视图
+
+PKMer 群友上善若水发了一个无序列表卡片布局的 CSS，配合使用了一下，很棒!!!
+
+![2024-03-13_QuickAdd脚本-配合FolderNotes及Markmind插件生成文件大纲导图_IMG-3](https://cdn.pkmer.cn/images/202403171814986.gif!pkmer)
 
 ## QuickAdd Macro 脚本
 

--- a/10-Obsidian/Obsidian社区插件/Quickadd/quickadd.md
+++ b/10-Obsidian/Obsidian社区插件/Quickadd/quickadd.md
@@ -7,7 +7,7 @@ author: windilycloud
 type: basic
 draft: false
 editable: false
-modified: 20240111113104
+modified: 20240311182148
 ---
 
 # Obsidian 插件：QuickAdd 自动化操作的编辑器
@@ -31,6 +31,7 @@ modified: 20240111113104
 - [[copy-selection-in-canvas]]
 - [[QuickAdd脚本-随机漫游笔记]]
 - [[Quickadd脚本-为深浅模式配置不同的主题]]
+- [[QuickAdd脚本-Project项目选项栏]]
 
 ## 参考资料
 

--- a/10-Obsidian/Obsidian社区插件/Quickadd/quickadd.md
+++ b/10-Obsidian/Obsidian社区插件/Quickadd/quickadd.md
@@ -32,6 +32,7 @@ modified: 20240311182148
 - [[QuickAdd脚本-随机漫游笔记]]
 - [[Quickadd脚本-为深浅模式配置不同的主题]]
 - [[QuickAdd脚本-Project项目选项栏]]
+- [[QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹)]]
 
 ## 参考资料
 

--- a/10-Obsidian/Obsidian社区插件/Quickadd/quickadd.md
+++ b/10-Obsidian/Obsidian社区插件/Quickadd/quickadd.md
@@ -33,6 +33,8 @@ modified: 20240311182148
 - [[Quickadd脚本-为深浅模式配置不同的主题]]
 - [[QuickAdd脚本-Project项目选项栏]]
 - [[QuickAdd脚本-Obsidian批量重命名(笔记-附件-文件夹)]]
+- [[QuickAdd脚本-配合FolderNotes及Markmind插件生成文件大纲导图]]
+- [[QuickAdd脚本-复制wiki对应文档内容并删除文件]]
 
 ## 参考资料
 


### PR DESCRIPTION
## Mod

- [[2023-11-24_自定义Excalidraw脚本-默认应用打开图片]]
	- [x] 设置选项框，除了默认应用打开外，还可以自定义多个不同软件打开
- [[2024-02-21_QuickAdd脚本-利用Canvas平铺笔记|QuickAdd 脚本 - 利用 Canvas 平铺笔记]]
	- [x] 对于生成的 Canvas 的 id 值转为字符串，不然会存在问题，改为字符串形式。 ✅ 2024-03-05
	- [x] 推荐插件：[Obsidian-canvas-minimap (github.com)](https://github.com/ifree/Obsidian-canvas-minimap) ✅ 2024-03-05
	- [x] 不同等级的标题对应卡片颜色不同 ✅ 2024-03-05
- [[2024-01-13_自定义Excalidraw脚本-画板与Kanban得梦幻结合，可像PPT一样演示！]]
	- [x] 当选中一个 Frame 时，不再弹出选项框，而是更新 frame 大纲 (无缩略图) ✅ 2024-03-05
	- [x] 修复对 Frame 排序后无法生效的问题 ✅ 2024-03-05
	- [x] 添加设置Kanban宽度选项->可以随时调整宽度 ✅ 2024-03-06
		- 以后需要配置参数的脚本全部设置可自动弹窗输入设置
	- 关联：[[2024-03-08_自定义Excalidraw脚本-QuickSwitchFrame-简单的Frame切换大纲]]
- [[2023-11-14_自定义Excalidraw脚本-OCR自动提取图片文字(可批量可修改)]]
	- [x] 添加空白区域或者空白边框时可以进行文字输入
	- [x] 上传本地 Paddleocr 模型附件到企业微信群文件
- [x] 修改 Bookxnote 和 Zotero 与 Excalidraw 联动的脚本的嵌入链接格式
	- [[2023-09-29_自定义Excalidraw脚本——实现Zotero与Excalidraw的联动]]
		- 修改嵌入链接的格式为 `[item](link)`
	- [[2023-12-19_自定义Excalidraw脚本-实现Excalidraw与BookxNote的联动]]
		- 修改嵌入链接的格式为 `[book](link)`
		- 添加注意事项 ->只能读取笔记大纲数据 ->设置笔记自动摘录到大纲选项


## Docs
- [x] [[2024-03-08_自定义Excalidraw脚本-QuickSwitchFrame-简单的Frame切换大纲]] ✅ 2024-03-09
- [x] [[2024-03-08_QuickAdd脚本-Project项目选项栏]] ✅ 2024-03-11
- [x] [[2024-03-03_QuickAdd脚本-Obsidian文件的批量重命名]]
  -  📺需要录制视频讲解一下：搜索、正则、替换、日志、撤销、专业软件重命名。
